### PR TITLE
Refactored the MaskFormat class and related logic to allow 'd', 'hh', 'A', and 'a' formats

### DIFF
--- a/src/PickerInput/Selector/Input.tsx
+++ b/src/PickerInput/Selector/Input.tsx
@@ -55,7 +55,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
     active,
     showActiveCls = true,
     suffixIcon,
-    format,
+    format: originalFormat,
     validateFormat,
     onChange,
     onInput,
@@ -82,6 +82,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
   const [forceSelectionSyncMark, forceSelectionSync] = React.useState<object>(null);
 
   const inputValue = internalInputValue || '';
+  const format = originalFormat?.replace(/A$/, 'AA')?.replace(/a$/, 'aa');
 
   // Sync value if needed
   React.useEffect(() => {
@@ -289,7 +290,7 @@ const Input = React.forwardRef<InputRef, InputProps>((props, ref) => {
 
       // =============== Number ===============
       default:
-        if (!isNaN(Number(key))) {
+        if (!isNaN(Number(key)) || ['A', 'P', 'M', 'a', 'p', 'm'].includes(key)) {
           nextCellText = focusCellText + key;
           nextFillText = nextCellText;
         }


### PR DESCRIPTION
Fixes https://github.com/bigbinary/neeto-engineering-web/issues/788

- Refactored the MaskFormat class and related logic to allow 'd', 'hh', 'A', and 'a' formats.
- I have created a `production` branch in addition to the `master` branch to release incremental changes on the current version of `rc-picker` supported by `antd`. The `production` branch is branched from tag `v4.3.0`.
- In future upgrades of `antd`, verify the `rc-picker` version upgrades; rebase the `production` branch with the associated `tag` and release a new version.
- I have added a GitHub workflow to automatically release a new NPM version whenever a branch is merged to the `production` branch with necessary labels.

Demo: https://abhay-ashokan.neetorecord.com/watch/68b875b2-7343-4ff5-9102-c5309727b215

patch _t
@AbhayVAshokan _a