### PR TITLE
Adds support to pass custom function to replace getNow in generateConfig.

### DIFF
--- a/src/PickerInput/SinglePicker.tsx
+++ b/src/PickerInput/SinglePicker.tsx
@@ -99,7 +99,9 @@ export interface BasePickerProps<DateType extends object = any>
 
 export interface PickerProps<DateType extends object = any>
   extends BasePickerProps<DateType>,
-    Omit<SharedTimeProps<DateType>, 'format' | 'defaultValue'> {}
+    Omit<SharedTimeProps<DateType>, 'format' | 'defaultValue'> {
+  getNow?: () => string;
+}
 
 /** Internal usage. For cross function get same aligned props */
 export type ReplacedPickerProps<DateType extends object = any> = {

--- a/src/PickerInput/hooks/useFilledProps.ts
+++ b/src/PickerInput/hooks/useFilledProps.ts
@@ -41,6 +41,7 @@ type PickedProps<DateType extends object = any> = Pick<
   defaultValue?: any;
   pickerValue?: any;
   defaultPickerValue?: any;
+  getNow?: () => string;
 };
 
 type ExcludeBooleanType<T> = T extends boolean ? never : T;
@@ -161,6 +162,10 @@ export default function useFilledProps<
   const filledProps = React.useMemo(
     () => ({
       ...props,
+      generateConfig: {
+        ...generateConfig,
+        getNow: props.getNow || props.generateConfig.getNow,
+      },
       prefixCls,
       locale: mergedLocale,
       picker,


### PR DESCRIPTION
Part of https://github.com/bigbinary/neeto-ui/issues/2344

Demo: https://deepak-jose.neetorecord.com/watch/ace8d14e-ca06-42ac-aaa9-affe51287990