### PR TITLE
Wrap README prose at 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 # rc-picker
 
-[![NPM version][npm-image]][npm-url] [![build status][github-actions-image]][github-actions-url] [![Codecov][codecov-image]][codecov-url] [![npm download][download-image]][download-url] [![bundle size][bundlephobia-image]][bundlephobia-url]
+[![NPM version][npm-image]][npm-url] [![build
+status][github-actions-image]][github-actions-url]
+[![Codecov][codecov-image]][codecov-url] [![npm
+download][download-image]][download-url] [![bundle
+size][bundlephobia-image]][bundlephobia-url]
 
 [npm-image]: http://img.shields.io/npm/v/rc-picker.svg?style=flat-square
 [npm-url]: http://npmjs.org/package/rc-picker


### PR DESCRIPTION
Wraps prose in `README.md` at 80 columns so it stops scrolling
horizontally in editors without soft wrap.

Only paragraph text is rewrapped. Code blocks, tables, headings, URLs and
HTML are left byte for byte alone, and the rendered output is unchanged.

Opened by `gh-repo-compliancy`.
